### PR TITLE
4-get-api-review-review_id; added errror handlers

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -33,3 +33,49 @@ describe("GET", () => {
     });
   });
 });
+describe("/api/reviews/:reviews_id", () => {
+  test("200: Returns a review by id number", () => {
+    return request(app)
+      .get("/api/reviews/1")
+      .expect(200)
+      .then((res) => {
+        const review = res.body.review;
+
+        expect(review[0]).toEqual(
+          expect.objectContaining({
+            review_id: 1,
+            title: "Agricola",
+            review_body: "Farmyard fun!",
+            designer: "Uwe Rosenberg",
+            review_img_url:
+              "https://www.golenbock.com/wp-content/uploads/2015/01/placeholder-user.png",
+            votes: 1,
+            category: "euro game",
+            owner: "mallionaire",
+            created_at: "2021-01-18T10:00:20.514Z",
+          })
+        );
+      });
+  });
+  describe("/api/reviews/:reviews_id", () => {
+    test("400: Returns error for non-numerical ID input", () => {
+      return request(app)
+        .get("/api/reviews/invalidInput")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Invalid request input");
+        });
+    });
+  });
+  describe("/api/reviews/:reviews_id", () => {
+    test("404: Returns error when input does not exist", () => {
+      return request(app)
+        .get("/api/reviews/99999")
+        .expect(404)
+        .then(({ body }) => {
+          console.log(body);
+          expect(body.msg).toBe("99999 Not found");
+        });
+    });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -1,12 +1,20 @@
 const express = require("express");
-const { getCategories, getReviews } = require("./controllers/categories");
+const { getCategories, getReview } = require("./controllers/categories");
 const app = express();
 
 app.get("/api/categories", getCategories);
-app.get("/api/reviews", getReviews); //current task
+app.get("/api/reviews/:review_id", getReview);
 
 app.use((err, req, res, next) => {
-  res.status(500).send({ msg: err.message });
+  if (err.status && err.msg) {
+    res.status(err.status).send({ msg: err.msg });
+  } else if (err.code === "22P02") {
+    res.status(400).send({ msg: "Invalid request input" });
+  } else if (err.code === "P0002") {
+    res.status(404).send({ msg: "Not found" });
+  } else {
+    res.status(500).send({ msg: "Internal server error" });
+  }
 });
 
 module.exports = app;

--- a/controllers/categories.js
+++ b/controllers/categories.js
@@ -1,12 +1,15 @@
-const { fetchCategories, fetchReviews } = require("../models/categories");
+const { fetchCategories, fetchReview } = require("../models/categories");
 
 exports.getCategories = (req, res) => {
   fetchCategories().then((categories) => {
     res.status(200).send({ categories });
   });
 };
-exports.getReviews = (req, res) => {
-  fetchReviews().then((reviews) => {
-    res.status(200).send({ reviews });
-  });
-}; //current task
+exports.getReview = (req, res, next) => {
+  const { review_id } = req.params;
+  fetchReview(review_id)
+    .then((review) => {
+      res.status(200).send({ review });
+    })
+    .catch((err) => next(err));
+};

--- a/models/categories.js
+++ b/models/categories.js
@@ -1,8 +1,19 @@
 const db = require("../db/connection.js");
 
-exports.fetchCategories = (req, res) => {
-  return db.query(`SELECT * FROM categories`).then((res) => res.rows);
+exports.fetchCategories = () => {
+  return db.query(`SELECT * FROM categories;`).then((result) => result.rows);
 };
-exports.fetchReviews = (req, res) => {
-  return db.query(`SELECT * FROM reviews`).then((res) => res.rows);
-}; //current task
+exports.fetchReview = (review_id) => {
+  return db
+    .query(`SELECT * FROM reviews WHERE review_id = $1; `, [review_id])
+    .then((result) => {
+      const returnedReview = result.rows;
+      if (returnedReview.length < 1) {
+        return Promise.reject({
+          status: 404,
+          msg: `${review_id} Not found`,
+        });
+      }
+      return returnedReview;
+    });
+};


### PR DESCRIPTION
I have added some custom errors to handle instances where the id provided by the client exceeds those in the database, where the client provides an invalid input such as a string, and a 500 internal server error. 
Although I have a test for the 404 in response, the test is built around expecting an invalid endpoint whereas the logic in my code for the error is built around the array being returned having a length of less than 1. I'm wondering if the test should reflect the logic in the code more. 